### PR TITLE
Medical Dispatch / Civilian Hardsuit additions.

### DIFF
--- a/Resources/Prototypes/_AurumS/Loadouts/MedicalDispatch/meddispatch_loadouts.yml
+++ b/Resources/Prototypes/_AurumS/Loadouts/MedicalDispatch/meddispatch_loadouts.yml
@@ -1,0 +1,34 @@
+#Medical Dispatch Hardsuits
+
+- type: loadout
+  id: MedicalDispatchCMOHardsuit
+  price: 0
+  equipment:
+    outerClothing: ClothingOuterHardsuitMedical
+
+- type: loadout
+  id: MedicalDispatchTraumaHardsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MedicalDispatchElite
+  price: 4000
+  equipment:
+    outerClothing: ClothingOuterHardsuitTrauma
+
+- type: loadout
+  id: MedicalDispatchATUJumpsuit
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MedicalDispatchElite
+  equipment:
+    jumpsuit: ClothingUniformJumpsuitATU
+
+- type: loadout
+  id: MedicalDispatchATUJumpskirt
+  effects:
+  - !type:GroupLoadoutEffect
+    proto: MedicalDispatchElite
+  equipment:
+    jumpsuit: ClothingUniformJumpskirtTAF
+
+

--- a/Resources/Prototypes/_AurumS/Loadouts/civilian_loadout.yml
+++ b/Resources/Prototypes/_AurumS/Loadouts/civilian_loadout.yml
@@ -1,0 +1,22 @@
+#Civilian Grade Hardsuits
+
+- type: loadout
+  id: ContractorClothingCEHardsuit
+  price: 7600
+  equipment:
+    outerClothing: ClothingOuterHardsuitEngineeringWhite
+
+- type: loadout
+  id: ContractorClothingRDHardsuit
+  price: 8000
+  equipment:
+    outerClothing: ClothingOuterHardsuitRd
+
+#Civilian Grade Modsuits
+
+- type: loadout
+  id: ContractorBackpackModsuitRD
+  price: 12500
+  equipment:
+    back: ClothingModsuitResearchDirectorPowerCell
+

--- a/Resources/Prototypes/_AurumS/Loadouts/medicaldispatch_outerclothing_group.yml
+++ b/Resources/Prototypes/_AurumS/Loadouts/medicaldispatch_outerclothing_group.yml
@@ -1,0 +1,21 @@
+- type: loadoutGroup
+  id: MDDOuterclothing
+  name: loadout-group-contractor-outerclothing
+  minLimit: 0
+  loadouts:
+  - ContractorClothingOuterCoatLab
+  - ContractorClothingOuterCoatLabGene
+  - ContractorClothingOuterCoatLabChem
+  - ContractorClothingOuterCoatLabViro
+  - ContractorClothingOuterBioScientist
+  - ContractorClothingOuterWinterCoat
+  - ContractorClothingOuterWinterCoatLong
+  - ContractorClothingOuterWinterMed
+  - ContractorClothingOuterWinterChem
+  - ContractorClothingOuterCoatParamedicWB
+  - ContractorClothingOuterWinterPara
+  - ContractorClothingOuterCoatLabSeniorPhysician
+  - ContractorClothingOuterHardsuitVoidParamed
+  - MedicalDispatchCMOHardsuit
+  - MedicalDispatchTraumaHardsuit
+

--- a/Resources/Prototypes/_AurumS/Loadouts/playtime_requirement_groups.yml
+++ b/Resources/Prototypes/_AurumS/Loadouts/playtime_requirement_groups.yml
@@ -1,0 +1,11 @@
+- type: loadoutEffectGroup
+  id: MedicalDispatchElite
+  effects:
+  - !type:JobRequirementLoadoutEffect
+    requirement:
+      !type:DepartmentTimeRequirement
+      department: Medical
+      time: 72000 # 20 hours
+
+
+

--- a/Resources/Prototypes/_Mono/Loadouts/MedicalDispatch/role_loadouts_mdd.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/MedicalDispatch/role_loadouts_mdd.yml
@@ -6,7 +6,8 @@
   - MdMedicJumpsuit
   - MdMedicGloves
   - MdMedicBackpack
-  - ContractorOuterClothing
+  # - ContractorOuterClothing - Aurum - MD personnel having their own proper hardsuit section.
+  - MDDOuterclothing # Aurum - MD personnel having their own proper outer clothing section.
   - ContractorShoes
   - ContractorFace
   - ContractorGlasses

--- a/Resources/Prototypes/_Mono/Loadouts/MedicalDispatch/universal_groups.yml
+++ b/Resources/Prototypes/_Mono/Loadouts/MedicalDispatch/universal_groups.yml
@@ -20,6 +20,10 @@
   - ContractorClothingUniformJumpskirtGenetics
   - ContractorClothingUniformJumpsuitPsychologist
   - ContractorClothingUniformJumpskirtPsychologist
+  # Aurum - Start
+  - MedicalDispatchATUJumpsuit
+  - MedicalDispatchATUJumpskirt
+  # Aurum - End
   fallbacks:
   - MedicalDoctorJumpsuit
 

--- a/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
+++ b/Resources/Prototypes/_NF/Loadouts/contractor_loadout_groups.yml
@@ -216,11 +216,15 @@
   id: ContractorBackpack
   name: loadout-group-contractor-backpack
   loadouts:
+
   ## Mono start
   - ContractorClothingModsuitAtmostechPowerCell
   - ContractorClothingModsuitCaptainPowerCell
   - ContractorClothingModsuitEngineerPowerCell
   ## Mono end
+  ## Aurum Start
+  - ContractorBackpackModsuitRD
+  ## Aurum End
   - ContractorClothingBackpack
   - ContractorClothingBackpackDuffel
   - ContractorClothingBackpackSatchel
@@ -305,6 +309,10 @@
   - ContractorClothingOuterHardsuitVoidParamed
   - ContractorClothingOuterHardsuitUIEngineer
   - ContractorClothingOuterHardsuitUIPilot
+  ## Aurum Start
+  - ContractorClothingCEHardsuit
+  - ContractorClothingRDHardsuit
+  ## Aurum End
   ## Mono start
   - ContractorClothingOuterHardsuitAtmos
   - ContractorClothingOuterHardsuitCap

--- a/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
+++ b/Resources/Prototypes/_NF/Loadouts/role_loadouts.yml
@@ -276,7 +276,8 @@
   - DocJumpsuit
   - DocGloves
   - MdMedicBackpack
-  - ContractorOuterClothing
+  # - ContractorOuterClothing - Aurum - MD personnel having their own proper hardsuit section.
+  - MDDOuterclothing # Aurum - MD personnel having their own proper hardsuit section.
   - DocShoes
   - ContractorFace
   - ContractorGlasses


### PR DESCRIPTION


## About the PR
This PR adds two hardsuits and one modsuit to the civilian loadouts that should have already been there.
Following shortly, medical dispatch personnel and DoC got a proper section of hardsuits, mostly including medical hardsuits, outerclothing, and one hardsuit reserved for people with 20 hours in MD.
ATU jumpsuits have also been added to their loadout under a similar requirement.

The RD Modsuit includes a charged cell.

## Why / Balance
The RD / CE Hardsuit / RD Modsuit should have been in the civilian loadout for ages, even if they are "OP" and "Get rid of world hazards" (A.k.a; Radiation and heated areas).
They aren't that strong in terms of fights, and should be fine.

Medical Dispatch lack plenty of love, and I wanna fix that.

## How to test
>Go into game
>Check loadouts
>Hardsuits are there
>Go into medical dispatch loadouts
>Hardsuits and jumpsuits are there.

## Media
<img width="735" height="305" alt="CivHardsuitsPic1" src="https://github.com/user-attachments/assets/7712f587-8251-48da-973c-a0f845e7f657" />
<img width="727" height="308" alt="CivHardsuitsPic2" src="https://github.com/user-attachments/assets/9939e7de-0a00-45df-8af8-9891fdecbb33" />
<img width="725" height="365" alt="CivHardsuitsPic3" src="https://github.com/user-attachments/assets/2bb94bb5-1d3a-4667-89d1-e5f82dbefb8c" />
<img width="810" height="373" alt="MDDispatchNewClothing" src="https://github.com/user-attachments/assets/02a24988-e2fe-4b73-bbd5-2f1743567c6e" />
<img width="1013" height="920" alt="MDDispatchNewClothing2" src="https://github.com/user-attachments/assets/d187371b-7ed9-4487-9fe6-a9264e360ef6" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes


**Changelog**
:cl: Diggy
- tweak: Medical Dispatch now has their own medical-focused outerclothing selection.
- remove: Medical Dispatch no longer uses the general outer clothing loadout group, you might be dripless for a bit.
- tweak: RD Modsuit and CE / RD Hardsuits have been added to civilian loadouts.



