### PR TITLE
Make the game actually fun for new people

### DIFF
--- a/Content.Shared/Preferences/HumanoidCharacterProfile.cs
+++ b/Content.Shared/Preferences/HumanoidCharacterProfile.cs
@@ -34,7 +34,7 @@ namespace Content.Shared.Preferences
         public const int MaxLoadoutNameLength = 32;
         public const int MaxDescLength = 512;
 
-        public const int DefaultBalance = 75000;
+        public const int DefaultBalance = 250000; // Aurum - Starting player friendly change.
 
         //private readonly Dictionary<string, JobPriority> _jobPriorities; // Frontier: commented out during merge.
         //private readonly List<string> _antagPreferences; // Frontier: commented out during merge.


### PR DESCRIPTION


## About the PR
Starting balance from 75000 to 250000.

## Why / Balance
Monolith has a bunch of bad design in it, including noobbait for no real reason, most of the time this just bricks your character, and you are pretty much forced to either side with other people, or start a new save file where you didn't buy a ship that cost you most of your money but turned out to be shit.

This doesn't really change much, aside from the fact the game is a bit more lenient before it bricks you for trying to play it without picking the most effective options.

## How to test
Create a new character.
Check balance.

## Media
<img width="316" height="160" alt="StartingMoneyChange" src="https://github.com/user-attachments/assets/6ef7ff4a-7e0d-4d21-920b-9d51a508ce57" />


## Requirements
- [X] I have read and am following the [Pull Request and Changelog Guidelines](https://docs.spacestation14.com/en/general-development/codebase-info/pull-request-guidelines.html).
- [X] I have added media to this PR or it does not require an ingame showcase.
- [X] I can confirm this PR contains no AI-generated content, and did not use any AI-generated content.

## Breaking changes


**Changelog**
:cl:
- tweak: Starting balance changed from 75000 to 250000.

